### PR TITLE
switch from log4j dependency to slf4j dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,9 +123,14 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
-            <version>2.5</version>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.21</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>1.7.21</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/edu/mit/puzzle/cube/core/model/HuntStatusStore.java
+++ b/src/main/java/edu/mit/puzzle/cube/core/model/HuntStatusStore.java
@@ -1,24 +1,32 @@
 package edu.mit.puzzle.cube.core.model;
 
 import com.google.common.base.Joiner;
-import com.google.common.collect.*;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Table;
+
 import edu.mit.puzzle.cube.core.db.ConnectionFactory;
 import edu.mit.puzzle.cube.core.db.DatabaseHelper;
 import edu.mit.puzzle.cube.core.events.Event;
 import edu.mit.puzzle.cube.core.events.EventProcessor;
 import edu.mit.puzzle.cube.core.events.VisibilityChangeEvent;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
-import java.time.*;
-import java.util.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Clock;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
 public class HuntStatusStore {
 
-    private static Logger LOGGER = LogManager.getLogger(HuntStatusStore.class);
+    private static Logger LOGGER = LoggerFactory.getLogger(HuntStatusStore.class);
 
     private final ConnectionFactory connectionFactory;
     private final Clock clock;

--- a/src/main/java/edu/mit/puzzle/cube/core/model/SubmissionStore.java
+++ b/src/main/java/edu/mit/puzzle/cube/core/model/SubmissionStore.java
@@ -3,13 +3,15 @@ package edu.mit.puzzle.cube.core.model;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Ordering;
 import com.google.common.collect.Table;
+
 import edu.mit.puzzle.cube.core.db.ConnectionFactory;
 import edu.mit.puzzle.cube.core.db.DatabaseHelper;
 import edu.mit.puzzle.cube.core.events.Event;
 import edu.mit.puzzle.cube.core.events.EventProcessor;
 import edu.mit.puzzle.cube.core.events.SubmissionCompleteEvent;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.time.Clock;
 import java.time.Instant;
@@ -23,7 +25,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 public class SubmissionStore {
 
-    private static Logger LOGGER = LogManager.getLogger(SubmissionStore.class);
+    private static Logger LOGGER = LoggerFactory.getLogger(SubmissionStore.class);
     private static DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSX");
 
     private final ConnectionFactory connectionFactory;


### PR DESCRIPTION
This resolves these errors that we were seeing on every startup:

ERROR StatusLogger No log4j2 configuration file found. Using default configuration: logging only errors to the console.
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.

...and SLF4J generally seems easier to set up correctly (with slf4j-simple).