### PR TITLE
Type-safe DatabaseHelper.query method

### DIFF
--- a/src/main/java/edu/mit/puzzle/cube/core/model/VisibilityChange.java
+++ b/src/main/java/edu/mit/puzzle/cube/core/model/VisibilityChange.java
@@ -7,6 +7,8 @@ import com.google.auto.value.AutoValue;
 
 import java.time.Instant;
 
+import javax.annotation.Nullable;
+
 @AutoValue
 @JsonDeserialize(builder = AutoValue_VisibilityChange.Builder.class)
 public abstract class VisibilityChange {
@@ -19,6 +21,10 @@ public abstract class VisibilityChange {
         @JsonProperty("timestamp")
         @JsonDeserialize(using=InstantDeserializer.class)
         public abstract Builder setTimestamp(Instant timestamp);
+
+        @Nullable
+        @JsonProperty("visibilityHistoryId")
+        public abstract Builder setVisibilityHistoryId(Integer visibilityHistoryId);
 
         public abstract VisibilityChange build();
     }
@@ -34,4 +40,8 @@ public abstract class VisibilityChange {
     @JsonProperty("timestamp")
     @JsonSerialize(using=InstantSerializer.class)
     public abstract Instant getTimestamp();
+
+    @Nullable
+    @JsonProperty("visibilityHistoryId")
+    public abstract Integer getVisibilityHistoryId();
 }

--- a/src/test/java/edu/mit/puzzle/cube/core/model/HuntStatusStoreTest.java
+++ b/src/test/java/edu/mit/puzzle/cube/core/model/HuntStatusStoreTest.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Table;
 
 import edu.mit.puzzle.cube.core.AdjustableClock;
 import edu.mit.puzzle.cube.core.db.ConnectionFactory;
@@ -22,6 +21,7 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
@@ -71,10 +71,10 @@ public class HuntStatusStoreTest {
         assertTrue(statusChanged);
         assertEquals("UNLOCKED", huntStatusStore.getVisibility(TEST_TEAM_ID, TEST_PUZZLE_ID));
 
-        Table<Integer,String,Object> history = huntStatusStore.getVisibilityHistory(TEST_TEAM_ID, TEST_PUZZLE_ID);
-        assertEquals(1, history.rowKeySet().size());
-        assertEquals(clock.instant(), history.get(0, "timestamp"));
-        assertEquals("UNLOCKED", history.get(0, "status"));
+        List<VisibilityChange> history = huntStatusStore.getVisibilityHistory(TEST_TEAM_ID, TEST_PUZZLE_ID);
+        assertEquals(1, history.size());
+        assertEquals(clock.instant(), history.get(0).getTimestamp());
+        assertEquals("UNLOCKED", history.get(0).getStatus());
 
         verify(eventProcessor, times(1)).process(any(Event.class));
     }
@@ -88,10 +88,10 @@ public class HuntStatusStoreTest {
         assertFalse(statusChanged);
         assertEquals("UNLOCKED", huntStatusStore.getVisibility(TEST_TEAM_ID, TEST_PUZZLE_ID));
 
-        Table<Integer,String,Object> history = huntStatusStore.getVisibilityHistory(TEST_TEAM_ID, TEST_PUZZLE_ID);
-        assertEquals(1, history.rowKeySet().size());
-        assertEquals(clock.instant(), history.get(0, "timestamp"));
-        assertEquals("UNLOCKED", history.get(0, "status"));
+        List<VisibilityChange> history = huntStatusStore.getVisibilityHistory(TEST_TEAM_ID, TEST_PUZZLE_ID);
+        assertEquals(1, history.size());
+        assertEquals(clock.instant(), history.get(0).getTimestamp());
+        assertEquals("UNLOCKED", history.get(0).getStatus());
 
         verify(eventProcessor, times(1)).process(any(Event.class));
     }
@@ -104,8 +104,8 @@ public class HuntStatusStoreTest {
         assertEquals(visibilityStatusSet.getDefaultVisibilityStatus(),
                 huntStatusStore.getVisibility(TEST_TEAM_ID, TEST_PUZZLE_ID));
 
-        Table<Integer,String,Object> history = huntStatusStore.getVisibilityHistory(TEST_TEAM_ID, TEST_PUZZLE_ID);
-        assertEquals(0, history.rowKeySet().size());
+        List<VisibilityChange> history = huntStatusStore.getVisibilityHistory(TEST_TEAM_ID, TEST_PUZZLE_ID);
+        assertEquals(0, history.size());
 
         verifyZeroInteractions(eventProcessor);
     }
@@ -118,9 +118,9 @@ public class HuntStatusStoreTest {
         assertEquals(visibilityStatusSet.getDefaultVisibilityStatus(),
                 huntStatusStore.getVisibility(TEST_TEAM_ID, TEST_PUZZLE_ID));
 
-        Table<Integer,String,Object> history = huntStatusStore.getVisibilityHistory(
+        List<VisibilityChange> history = huntStatusStore.getVisibilityHistory(
                 TEST_TEAM_ID, TEST_PUZZLE_ID);
-        assertEquals(0, history.rowKeySet().size());
+        assertEquals(0, history.size());
 
         verifyZeroInteractions(eventProcessor);
     }
@@ -141,13 +141,13 @@ public class HuntStatusStoreTest {
         assertTrue(statusChanged);
         assertEquals("SOLVED", huntStatusStore.getVisibility(TEST_TEAM_ID, TEST_PUZZLE_ID));
 
-        Table<Integer,String,Object> history = huntStatusStore.getVisibilityHistory(TEST_TEAM_ID, TEST_PUZZLE_ID);
-        assertEquals(2, history.rowKeySet().size());
+        List<VisibilityChange> history = huntStatusStore.getVisibilityHistory(TEST_TEAM_ID, TEST_PUZZLE_ID);
+        assertEquals(2, history.size());
 
-        assertEquals(firstTimestamp, history.get(0, "timestamp"));
-        assertEquals("UNLOCKED", history.get(0, "status"));
-        assertEquals(secondTimestamp, history.get(1, "timestamp"));
-        assertEquals("SOLVED", history.get(1, "status"));
+        assertEquals(firstTimestamp, history.get(0).getTimestamp());
+        assertEquals("UNLOCKED", history.get(0).getStatus());
+        assertEquals(secondTimestamp, history.get(1).getTimestamp());
+        assertEquals("SOLVED", history.get(1).getStatus());
 
         verify(eventProcessor, times(2)).process(any(Event.class));
     }


### PR DESCRIPTION
Add a type-safe DatabaseHelper.query method that properly converts SQL timestamps to Instants, and returns lists of model objects instead of Guava Tables of untyped Java objects.

Change queries that work with timestamps (submissions and visibility changes) to use the new DatabaseHelper method.

This change was prompted because I was intermittently seeing DatabaseHelper.internallyCastTimestamps fail to recognize/parse a timestamp, which would then result in a "java.lang.String cannot be cast to java.time.Instant" error in the model layer. I think this approach is better than "searching" for timestamp columns by always attempting to cast every field to a timestamp.

I'd like to change more of the DatabaseHelper.query calls throughout the server to use this new interface, but wanted to get your input first. I'm concerned that this only works for model classes whose JSON field names exactly match the database schema - we might need to make this a little fancier / more customizable to handle cases where they don't match exactly and completely.