### PR TITLE
Start adding HintRequest support to Cube

### DIFF
--- a/src/main/java/edu/mit/puzzle/cube/core/CubeApplication.java
+++ b/src/main/java/edu/mit/puzzle/cube/core/CubeApplication.java
@@ -10,8 +10,9 @@ import edu.mit.puzzle.cube.core.environments.ProductionEnvironment;
 import edu.mit.puzzle.cube.core.environments.ServiceEnvironment;
 import edu.mit.puzzle.cube.core.events.CompositeEventProcessor;
 import edu.mit.puzzle.cube.core.events.PeriodicTimerEvent;
-import edu.mit.puzzle.cube.core.model.PuzzleStore;
+import edu.mit.puzzle.cube.core.model.HintRequestStore;
 import edu.mit.puzzle.cube.core.model.HuntStatusStore;
+import edu.mit.puzzle.cube.core.model.PuzzleStore;
 import edu.mit.puzzle.cube.core.model.SubmissionStore;
 import edu.mit.puzzle.cube.core.model.UserStore;
 import edu.mit.puzzle.cube.core.serverresources.AbstractCubeResource;
@@ -38,6 +39,7 @@ public class CubeApplication extends Application {
     private final HuntStatusStore huntStatusStore;
     private final UserStore userStore;
     private final PuzzleStore puzzleStore;
+    private final HintRequestStore hintRequestStore;
     private final CompositeEventProcessor eventProcessor;
 
     private final Service timingEventService;
@@ -86,6 +88,9 @@ public class CubeApplication extends Application {
         puzzleStore = new PuzzleStore(
                 huntDefinition.getPuzzles()
         );
+        hintRequestStore = new HintRequestStore(
+                connectionFactory
+        );
 
         huntDefinition.addToEventProcessor(
                 eventProcessor,
@@ -133,6 +138,7 @@ public class CubeApplication extends Application {
         getContext().getAttributes().put(AbstractCubeResource.HUNT_STATUS_STORE_KEY, huntStatusStore);
         getContext().getAttributes().put(AbstractCubeResource.USER_STORE_KEY, userStore);
         getContext().getAttributes().put(AbstractCubeResource.PUZZLE_STORE_KEY, puzzleStore);
+        getContext().getAttributes().put(AbstractCubeResource.HINT_REQUEST_STORE_KEY, hintRequestStore);
         getContext().getAttributes().put(AbstractCubeResource.EVENT_PROCESSOR_KEY, eventProcessor);
 
         return new CubeRestlet(getContext());

--- a/src/main/java/edu/mit/puzzle/cube/core/CubeRestlet.java
+++ b/src/main/java/edu/mit/puzzle/cube/core/CubeRestlet.java
@@ -24,6 +24,8 @@ public class CubeRestlet extends Filter {
         Router router = new Router(context);
         router.attach("/authorized", AuthorizedResource.class);
         router.attach("/events", EventsResource.class);
+        router.attach("/hintrequests", HintRequestsResource.class);
+        router.attach("/hintrequests/{id}", HintRequestResource.class);
         router.attach("/puzzle/{id}", PuzzleResource.class);
         router.attach("/submissions", SubmissionsResource.class);
         router.attach("/submissions/{id}", SubmissionResource.class);

--- a/src/main/java/edu/mit/puzzle/cube/core/model/HintRequest.java
+++ b/src/main/java/edu/mit/puzzle/cube/core/model/HintRequest.java
@@ -1,0 +1,48 @@
+package edu.mit.puzzle.cube.core.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.google.auto.value.AutoValue;
+
+import java.time.Instant;
+
+import javax.annotation.Nullable;
+
+@AutoValue
+@JsonDeserialize(builder = AutoValue_HintRequest.Builder.class)
+public abstract class HintRequest {
+    @AutoValue.Builder
+    public static abstract class Builder {
+        @JsonProperty("hintRequestId") public abstract Builder setHintRequestId(Integer hintRequestId);
+        @JsonProperty("teamId") public abstract Builder setTeamId(String teamId);
+        @JsonProperty("puzzleId") public abstract Builder setPuzzleId(String puzzleId);
+        @JsonProperty("status") public abstract Builder setStatus(HintRequestStatus status);
+        @JsonProperty("callerUsername") public abstract Builder setCallerUsername(String callerUsername);
+        @JsonProperty("request") public abstract Builder setRequest(@Nullable String request);
+        @JsonProperty("response") public abstract Builder setResponse(@Nullable String response);
+
+        @JsonProperty("timestamp")
+        @JsonDeserialize(using=InstantDeserializer.class)
+        public abstract Builder setTimestamp(Instant timestamp);
+
+        public abstract HintRequest build();
+    }
+
+    public static Builder builder() {
+        return new AutoValue_HintRequest.Builder();
+    }
+
+    @Nullable @JsonProperty("hintRequestId") public abstract Integer getHintRequestId();
+    @Nullable @JsonProperty("teamId") public abstract String getTeamId();
+    @Nullable @JsonProperty("puzzleId") public abstract String getPuzzleId();
+    @Nullable @JsonProperty("status") public abstract HintRequestStatus getStatus();
+    @Nullable @JsonProperty("callerUsername") public abstract String getCallerUsername();
+    @Nullable @JsonProperty("request") public abstract String getRequest();
+    @Nullable @JsonProperty("response") public abstract String getResponse();
+
+    @Nullable
+    @JsonProperty("timestamp")
+    @JsonSerialize(using=InstantSerializer.class)
+    public abstract Instant getTimestamp();
+}

--- a/src/main/java/edu/mit/puzzle/cube/core/model/HintRequestStatus.java
+++ b/src/main/java/edu/mit/puzzle/cube/core/model/HintRequestStatus.java
@@ -1,0 +1,28 @@
+package edu.mit.puzzle.cube.core.model;
+
+import com.google.common.collect.ImmutableSet;
+
+import java.util.Set;
+
+public enum HintRequestStatus {
+    REQUESTED,
+    ASSIGNED,
+    ANSWERED,
+    REJECTED;
+
+    private static Set<HintRequestStatus> ASSIGNED_STATUSES =
+            ImmutableSet.of(ASSIGNED, ANSWERED, REJECTED);
+    private static Set<HintRequestStatus> TERMINAL_STATUSES = ImmutableSet.of(ANSWERED, REJECTED);
+
+    public static HintRequestStatus getDefault() {
+        return REQUESTED;
+    }
+
+    public boolean isAssigned() {
+        return ASSIGNED_STATUSES.contains(this);
+    }
+
+    public boolean isTerminal() {
+        return TERMINAL_STATUSES.contains(this);
+    }
+}

--- a/src/main/java/edu/mit/puzzle/cube/core/model/HintRequestStore.java
+++ b/src/main/java/edu/mit/puzzle/cube/core/model/HintRequestStore.java
@@ -1,0 +1,98 @@
+package edu.mit.puzzle.cube.core.model;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+
+import edu.mit.puzzle.cube.core.db.ConnectionFactory;
+import edu.mit.puzzle.cube.core.db.DatabaseHelper;
+
+import java.sql.Timestamp;
+import java.time.Clock;
+import java.util.List;
+import java.util.Optional;
+
+import javax.annotation.Nullable;
+
+public class HintRequestStore {
+    private final ConnectionFactory connectionFactory;
+    private final Clock clock;
+
+    public HintRequestStore(
+            ConnectionFactory connectionFactory
+    ) {
+        this.connectionFactory = connectionFactory;
+        this.clock = Clock.systemUTC();
+    }
+
+    public boolean createHintRequest(HintRequest hintRequest) {
+        return DatabaseHelper.insert(
+                connectionFactory,
+                "INSERT INTO hint_requests (puzzleId, teamId, request, timestamp) " +
+                        "VALUES (?,?,?,?)",
+                Lists.newArrayList(
+                        hintRequest.getPuzzleId(),
+                        hintRequest.getTeamId(),
+                        hintRequest.getRequest(),
+                        Timestamp.from(clock.instant()))
+        ).isPresent();
+    }
+
+    public boolean updateHintRequest(
+            int hintRequestId,
+            HintRequestStatus status,
+            @Nullable String callerUsername,
+            @Nullable String response
+    ) {
+        boolean updated = DatabaseHelper.update(
+                connectionFactory,
+                "UPDATE hint_requests SET status = ?, callerUsername = ?, response = ? " +
+                "WHERE hintRequestId = ? AND (status <> ? OR callerUsername <> ? OR response <> ?)",
+                Lists.newArrayList(
+                        status.toString(),
+                        callerUsername,
+                        response,
+                        hintRequestId,
+                        status.toString(),
+                        callerUsername,
+                        response
+                )
+        ) > 0;
+
+        return updated;
+    }
+
+    public Optional<HintRequest> getHintRequest(int hintRequestId) {
+        List<HintRequest> hintRequests = DatabaseHelper.query(
+                connectionFactory,
+                "SELECT * FROM hint_requests WHERE hintRequestId = ?",
+                Lists.newArrayList(hintRequestId),
+                HintRequest.class
+        );
+
+        if (hintRequests.size() == 0) {
+            return Optional.empty();
+        } else if (hintRequests.size() > 1) {
+            throw new RuntimeException("Primary key violation in application layer");
+        }
+
+        return Optional.of(hintRequests.get(0));
+    }
+
+    public List<HintRequest> getNonTerminalHintRequests() {
+        return DatabaseHelper.query(
+                connectionFactory,
+                "SELECT * FROM hint_requests WHERE status <> 'ANSWERED' AND status <> 'REJECTED'",
+                ImmutableList.of(),
+                HintRequest.class
+        );
+    }
+
+    public List<HintRequest> getHintRequestsForTeamAndPuzzle(String teamId, String puzzleId) {
+        return DatabaseHelper.query(
+                connectionFactory,
+                "SELECT * FROM hint_requests WHERE teamId = ? AND puzzleId = ?",
+                ImmutableList.of(teamId, puzzleId),
+                HintRequest.class
+        );
+    }
+}

--- a/src/main/java/edu/mit/puzzle/cube/core/model/HintRequests.java
+++ b/src/main/java/edu/mit/puzzle/cube/core/model/HintRequests.java
@@ -1,0 +1,23 @@
+package edu.mit.puzzle.cube.core.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.auto.value.AutoValue;
+
+import java.util.List;
+
+@AutoValue
+@JsonDeserialize(builder = AutoValue_HintRequests.Builder.class)
+public abstract class HintRequests {
+	@AutoValue.Builder
+	public static abstract class Builder {
+		@JsonProperty("hintRequests") public abstract Builder setHintRequests(List<HintRequest> hintRequests);
+		public abstract HintRequests build();
+	}
+
+	public static Builder builder() {
+		return new AutoValue_HintRequests.Builder();
+	}
+
+	@JsonProperty("hintRequests") public abstract List<HintRequest> getHintRequests();
+}

--- a/src/main/java/edu/mit/puzzle/cube/core/permissions/CubeRole.java
+++ b/src/main/java/edu/mit/puzzle/cube/core/permissions/CubeRole.java
@@ -17,6 +17,7 @@ public abstract class CubeRole {
                     new TeamsPermission("*", PermissionAction.READ),
                     new SubmissionsPermission("*", PermissionAction.READ, PermissionAction.UPDATE),
                     new VisibilitiesPermission("*", PermissionAction.READ),
+                    new HintsPermission("*", PermissionAction.READ, PermissionAction.UPDATE),
                     new AnswersPermission()
             ));
 

--- a/src/main/java/edu/mit/puzzle/cube/core/permissions/HintsPermission.java
+++ b/src/main/java/edu/mit/puzzle/cube/core/permissions/HintsPermission.java
@@ -1,0 +1,9 @@
+package edu.mit.puzzle.cube.core.permissions;
+
+public class HintsPermission extends InstanceLevelPermission {
+    private static final long serialVersionUID = 1L;
+
+    public HintsPermission(String teamId, PermissionAction... actions) {
+        super("hints", teamId, actions);
+    }
+}

--- a/src/main/java/edu/mit/puzzle/cube/core/permissions/RolesAndInstanceLevelPermissions.java
+++ b/src/main/java/edu/mit/puzzle/cube/core/permissions/RolesAndInstanceLevelPermissions.java
@@ -53,7 +53,8 @@ public abstract class RolesAndInstanceLevelPermissions {
                         new UsersPermission(teamId, PermissionAction.READ),
                         new TeamsPermission(teamId, PermissionAction.READ),
                         new SubmissionsPermission(teamId, PermissionAction.CREATE, PermissionAction.READ),
-                        new VisibilitiesPermission(teamId, PermissionAction.READ)
+                        new VisibilitiesPermission(teamId, PermissionAction.READ),
+                        new HintsPermission(teamId, PermissionAction.CREATE, PermissionAction.READ)
                 ));
     }
 

--- a/src/main/java/edu/mit/puzzle/cube/core/serverresources/AbstractCubeResource.java
+++ b/src/main/java/edu/mit/puzzle/cube/core/serverresources/AbstractCubeResource.java
@@ -4,8 +4,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import edu.mit.puzzle.cube.core.events.Event;
 import edu.mit.puzzle.cube.core.events.EventProcessor;
-import edu.mit.puzzle.cube.core.model.PuzzleStore;
+import edu.mit.puzzle.cube.core.model.HintRequestStore;
 import edu.mit.puzzle.cube.core.model.HuntStatusStore;
+import edu.mit.puzzle.cube.core.model.PuzzleStore;
 import edu.mit.puzzle.cube.core.model.SubmissionStore;
 import edu.mit.puzzle.cube.core.model.UserStore;
 
@@ -19,12 +20,14 @@ public abstract class AbstractCubeResource extends ServerResource {
     public static final String HUNT_STATUS_STORE_KEY = "HUNT_STATUS_STORE";
     public static final String USER_STORE_KEY = "USER_STORE";
     public static final String PUZZLE_STORE_KEY = "PUZZLE_STORE";
+    public static final String HINT_REQUEST_STORE_KEY = "HINT_REQUEST_STORE";
     public static final String EVENT_PROCESSOR_KEY = "EVENT_PROCESSOR";
 
     protected SubmissionStore submissionStore;
     protected HuntStatusStore huntStatusStore;
     protected UserStore userStore;
     protected PuzzleStore puzzleStore;
+    protected HintRequestStore hintRequestStore;
     protected EventProcessor<Event> eventProcessor;
 
     public AbstractCubeResource() {
@@ -35,6 +38,7 @@ public abstract class AbstractCubeResource extends ServerResource {
         this.huntStatusStore = (HuntStatusStore) getContext().getAttributes().get(HUNT_STATUS_STORE_KEY);
         this.userStore = (UserStore) getContext().getAttributes().get(USER_STORE_KEY);
         this.puzzleStore = (PuzzleStore) getContext().getAttributes().get(PUZZLE_STORE_KEY);
+        this.hintRequestStore = (HintRequestStore) getContext().getAttributes().get(HINT_REQUEST_STORE_KEY);
         this.eventProcessor = (EventProcessor<Event>) getContext().getAttributes().get(EVENT_PROCESSOR_KEY);
     }
 }

--- a/src/main/java/edu/mit/puzzle/cube/core/serverresources/HintRequestResource.java
+++ b/src/main/java/edu/mit/puzzle/cube/core/serverresources/HintRequestResource.java
@@ -1,0 +1,78 @@
+package edu.mit.puzzle.cube.core.serverresources;
+
+import edu.mit.puzzle.cube.core.model.HintRequest;
+import edu.mit.puzzle.cube.core.model.PostResult;
+import edu.mit.puzzle.cube.core.permissions.HintsPermission;
+import edu.mit.puzzle.cube.core.permissions.PermissionAction;
+
+import org.apache.shiro.SecurityUtils;
+import org.apache.shiro.subject.Subject;
+import org.restlet.data.Status;
+import org.restlet.resource.Post;
+import org.restlet.resource.ResourceException;
+
+import java.util.Optional;
+
+public class HintRequestResource extends AbstractCubeResource {
+
+    private int getId() {
+        String idString = (String) getRequest().getAttributes().get("id");
+        if (idString == null) {
+            throw new IllegalArgumentException("id must be specified");
+        }
+        try {
+            return Integer.parseInt(idString);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("id is not valid");
+        }
+    }
+
+    @Post
+    public PostResult handlePost(HintRequest hintRequest) {
+        int id = getId();
+        if (hintRequest.getStatus() == null) {
+            throw new ResourceException(
+                    Status.CLIENT_ERROR_BAD_REQUEST,
+                    "A status must be specified when updating a hint request");
+        }
+
+        Optional<HintRequest> existingHintRequest = hintRequestStore.getHintRequest(id);
+        if (!existingHintRequest.isPresent()) {
+            throw new ResourceException(
+                    Status.CLIENT_ERROR_NOT_FOUND,
+                    String.format("Hint request %d does not exist", id));
+        }
+
+        Subject subject = SecurityUtils.getSubject();
+        subject.checkPermission(
+                new HintsPermission(existingHintRequest.get().getTeamId(), PermissionAction.UPDATE));
+
+        if (existingHintRequest.get().getStatus().isTerminal()) {
+            throw new ResourceException(
+                    Status.CLIENT_ERROR_BAD_REQUEST,
+                    "This hint request has already been handled and may no longer be changed.");
+        }
+
+        String currentUsername = (String) subject.getPrincipal();
+
+        if (existingHintRequest.get().getStatus().isAssigned()
+                && hintRequest.getStatus().isAssigned()
+                && !existingHintRequest.get().getCallerUsername().equals(currentUsername)) {
+            throw new ResourceException(
+                    Status.CLIENT_ERROR_BAD_REQUEST,
+                    String.format(
+                            "This hint request is already claimed by %s. It must be unassigned " +
+                            "before you can change it.",
+                            existingHintRequest.get().getCallerUsername()));
+        }
+
+        String callerUsername = null;
+        if (hintRequest.getStatus().isAssigned()) {
+            callerUsername = currentUsername;
+        }
+
+        boolean changed = hintRequestStore.updateHintRequest(
+                id, hintRequest.getStatus(), callerUsername, hintRequest.getResponse());
+        return PostResult.builder().setUpdated(changed).build();
+    }
+}

--- a/src/main/java/edu/mit/puzzle/cube/core/serverresources/HintRequestsResource.java
+++ b/src/main/java/edu/mit/puzzle/cube/core/serverresources/HintRequestsResource.java
@@ -1,0 +1,62 @@
+package edu.mit.puzzle.cube.core.serverresources;
+
+import com.google.common.base.Preconditions;
+
+import edu.mit.puzzle.cube.core.model.HintRequest;
+import edu.mit.puzzle.cube.core.model.HintRequests;
+import edu.mit.puzzle.cube.core.model.PostResult;
+import edu.mit.puzzle.cube.core.model.Visibility;
+import edu.mit.puzzle.cube.core.permissions.HintsPermission;
+import edu.mit.puzzle.cube.core.permissions.PermissionAction;
+
+import org.apache.shiro.SecurityUtils;
+import org.restlet.data.Status;
+import org.restlet.resource.Get;
+import org.restlet.resource.Post;
+import org.restlet.resource.ResourceException;
+
+import java.util.List;
+
+public class HintRequestsResource extends AbstractCubeResource {
+    @Get
+    public HintRequests handleGet() {
+        List<HintRequest> hintRequests;
+        String teamId = getQueryValue("teamId");
+        if (teamId != null && !teamId.isEmpty()) {
+            String puzzleId = getQueryValue("puzzleId");
+            Preconditions.checkArgument(
+                    puzzleId != null && !puzzleId.isEmpty(),
+                    "puzzleId must be specified"
+            );
+
+            SecurityUtils.getSubject().checkPermission(
+                    new HintsPermission(teamId, PermissionAction.READ)
+            );
+            hintRequests = hintRequestStore.getHintRequestsForTeamAndPuzzle(teamId, puzzleId);
+        } else {
+            SecurityUtils.getSubject().checkPermission(
+                    new HintsPermission("*", PermissionAction.READ)
+            );
+            hintRequests = hintRequestStore.getNonTerminalHintRequests();
+        }
+        return HintRequests.builder().setHintRequests(hintRequests).build();
+    }
+
+    @Post
+    public PostResult handlePost(HintRequest hintRequest) {
+        SecurityUtils.getSubject().checkPermission(
+                new HintsPermission(hintRequest.getTeamId(), PermissionAction.CREATE));
+        Visibility visibility = huntStatusStore.getVisibility(
+                hintRequest.getTeamId(),
+                hintRequest.getPuzzleId()
+        );
+        if (!huntStatusStore.getVisibilityStatusSet().allowsSubmissions(visibility.getStatus())) {
+            throw new ResourceException(
+                    Status.CLIENT_ERROR_BAD_REQUEST,
+                    "Requesting a hint is not allowed due to puzzle visibility");
+        }
+
+        boolean success = hintRequestStore.createHintRequest(hintRequest);
+        return PostResult.builder().setCreated(success).build();
+    }
+}

--- a/src/main/resources/cube.sql
+++ b/src/main/resources/cube.sql
@@ -89,5 +89,20 @@ CREATE TABLE visibility_history (
        timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
        PRIMARY KEY(visibilityHistoryId),
        FOREIGN KEY(teamId) REFERENCES teams(teamId),
-       FOREIGN KEY(puzzleId) REFERENCES puzzles(puzzleId)       
+       FOREIGN KEY(puzzleId) REFERENCES puzzles(puzzleId)
+);
+
+CREATE TABLE hint_requests (
+       hintRequestId ${auto_increment_type},
+       teamId VARCHAR(20),
+       puzzleId VARCHAR(40),
+       status VARCHAR(10) DEFAULT 'REQUESTED',
+       timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+       request TEXT,
+       response TEXT,
+       callerUsername VARCHAR(40),
+       PRIMARY KEY(hintRequestId),
+       FOREIGN KEY(teamId) REFERENCES teams(teamId),
+       FOREIGN KEY(puzzleId) REFERENCES puzzles(puzzleId),
+       FOREIGN KEY(callerUsername) REFERENCES users(username)
 );

--- a/src/test/java/edu/mit/puzzle/cube/serverresources/HintRequestsTest.java
+++ b/src/test/java/edu/mit/puzzle/cube/serverresources/HintRequestsTest.java
@@ -1,0 +1,158 @@
+package edu.mit.puzzle.cube.serverresources;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.ImmutableList;
+
+import edu.mit.puzzle.cube.core.HuntDefinition;
+import edu.mit.puzzle.cube.core.RestletTest;
+import edu.mit.puzzle.cube.core.db.CubeJdbcRealm;
+import edu.mit.puzzle.cube.core.events.CompositeEventProcessor;
+import edu.mit.puzzle.cube.core.model.HintRequest;
+import edu.mit.puzzle.cube.core.model.HintRequestStatus;
+import edu.mit.puzzle.cube.core.model.HuntStatusStore;
+import edu.mit.puzzle.cube.core.model.Puzzle;
+import edu.mit.puzzle.cube.core.model.VisibilityStatusSet;
+import edu.mit.puzzle.cube.modules.model.StandardVisibilityStatusSet;
+
+import org.apache.shiro.realm.Realm;
+import org.junit.Test;
+import org.restlet.data.ChallengeResponse;
+import org.restlet.data.ChallengeScheme;
+import org.restlet.data.Status;
+
+import java.sql.SQLException;
+import java.util.List;
+
+import static com.google.common.truth.Truth.assertThat;
+
+public class HintRequestsTest extends RestletTest {
+    private static final String PUZZLE_ID = "puzzle1";
+
+    private static final ChallengeResponse USER_ONE =
+            new ChallengeResponse(ChallengeScheme.HTTP_BASIC, "userone", "useronepassword");
+    private static final ChallengeResponse USER_TWO =
+            new ChallengeResponse(ChallengeScheme.HTTP_BASIC, "usertwo", "usertwopassword");
+    private static final ChallengeResponse TEAM =
+            new ChallengeResponse(ChallengeScheme.HTTP_BASIC, "team", "teampassword");
+
+    @Override
+    protected Realm createAuthenticationRealm() {
+        CubeJdbcRealm realm = new CubeJdbcRealm();
+        realm.setDataSource(serviceEnvironment.getConnectionFactory().getDataSource());
+        return realm;
+    }
+
+    protected HuntDefinition createHuntDefinition() {
+        return new HuntDefinition() {
+            @Override
+            public VisibilityStatusSet getVisibilityStatusSet() {
+                return new StandardVisibilityStatusSet();
+            }
+
+            @Override
+            public List<Puzzle> getPuzzles() {
+                return ImmutableList.of(Puzzle.create(PUZZLE_ID, "ANSWER"));
+            }
+
+            @Override
+            public void addToEventProcessor(
+                    CompositeEventProcessor eventProcessor,
+                    HuntStatusStore huntStatusStore
+            ) {
+            }
+        };
+    }
+
+    public void setUp() throws SQLException {
+        super.setUp();
+        addUser(USER_ONE, ImmutableList.of("writingteam"));
+        addUser(USER_TWO, ImmutableList.of("writingteam"));
+        addTeam(TEAM);
+        postHuntStart();
+    }
+
+    @Test
+    public void testRequestHintForInvisiblePuzzle() {
+        setCurrentUserCredentials(TEAM);
+        Status status = postExpectFailure(
+                "/hintrequests",
+                HintRequest.builder()
+                        .setTeamId(TEAM.getIdentifier())
+                        .setPuzzleId(PUZZLE_ID)
+                        .setRequest("help")
+                        .build()
+        );
+        assertThat(status.getCode()).isEqualTo(400);
+    }
+
+    @Test
+    public void testRequestAndResolveHint() {
+        postVisibility(TEAM.getIdentifier(), PUZZLE_ID, "UNLOCKED");
+
+        setCurrentUserCredentials(TEAM);
+        post(
+                "/hintrequests",
+                HintRequest.builder()
+                        .setTeamId(TEAM.getIdentifier())
+                        .setPuzzleId(PUZZLE_ID)
+                        .setRequest("help")
+                        .build()
+        );
+
+        JsonNode teamGetResult = get(
+                String.format("/hintrequests?teamId=%s&puzzleId=%s", TEAM.getIdentifier(), PUZZLE_ID)
+        );
+        assertThat(teamGetResult.get("hintRequests").size()).isEqualTo(1);
+        JsonNode hintRequest = teamGetResult.get("hintRequests").get(0);
+        assertThat(hintRequest.get("teamId").asText()).isEqualTo(TEAM.getIdentifier());
+        assertThat(hintRequest.get("puzzleId").asText()).isEqualTo(PUZZLE_ID);
+        assertThat(hintRequest.get("status").asText()).isEqualTo(HintRequestStatus.REQUESTED.name());
+        assertThat(hintRequest.get("request").asText()).isEqualTo("help");
+
+        setCurrentUserCredentials(USER_ONE);
+        post(
+                String.format("/hintrequests/%d", hintRequest.get("hintRequestId").asInt()),
+                HintRequest.builder()
+                        .setHintRequestId(hintRequest.get("hintRequestId").asInt())
+                        .setStatus(HintRequestStatus.ASSIGNED)
+                        .build()
+        );
+
+        JsonNode userGetResult = get(
+                String.format("/hintrequests", TEAM.getIdentifier(), PUZZLE_ID)
+        );
+        assertThat(userGetResult.get("hintRequests").size()).isEqualTo(1);
+        hintRequest = userGetResult.get("hintRequests").get(0);
+        assertThat(hintRequest.get("teamId").asText()).isEqualTo(TEAM.getIdentifier());
+        assertThat(hintRequest.get("puzzleId").asText()).isEqualTo(PUZZLE_ID);
+        assertThat(hintRequest.get("status").asText()).isEqualTo(HintRequestStatus.ASSIGNED.name());
+        assertThat(hintRequest.get("callerUsername").asText()).isEqualTo(USER_ONE.getIdentifier());
+        assertThat(hintRequest.get("request").asText()).isEqualTo("help");
+
+        post(
+                String.format("/hintrequests/%d", hintRequest.get("hintRequestId").asInt()),
+                HintRequest.builder()
+                        .setHintRequestId(hintRequest.get("hintRequestId").asInt())
+                        .setResponse("response")
+                        .setStatus(HintRequestStatus.ANSWERED)
+                        .build()
+        );
+
+        userGetResult = get(
+                String.format("/hintrequests", TEAM.getIdentifier(), PUZZLE_ID)
+        );
+        assertThat(userGetResult.get("hintRequests").size()).isEqualTo(0);
+
+        setCurrentUserCredentials(TEAM);
+        teamGetResult = get(
+                String.format("/hintrequests?teamId=%s&puzzleId=%s", TEAM.getIdentifier(), PUZZLE_ID)
+        );
+        assertThat(teamGetResult.get("hintRequests").size()).isEqualTo(1);
+        hintRequest = teamGetResult.get("hintRequests").get(0);
+        assertThat(hintRequest.get("teamId").asText()).isEqualTo(TEAM.getIdentifier());
+        assertThat(hintRequest.get("puzzleId").asText()).isEqualTo(PUZZLE_ID);
+        assertThat(hintRequest.get("status").asText()).isEqualTo(HintRequestStatus.ANSWERED.name());
+        assertThat(hintRequest.get("request").asText()).isEqualTo("help");
+        assertThat(hintRequest.get("response").asText()).isEqualTo("response");
+    }
+}


### PR DESCRIPTION
for issue #18 

still to do:
- hint currency: check token balance and deduct on request, refund (a variable amount?) on rejection
- introduce events for hints? maybe we avoid these until they're needed.