### PR TITLE
Set Visibilities in batches, allow for processing resulting VisibilityChangeEvents in batches

### DIFF
--- a/src/main/java/edu/mit/puzzle/cube/core/HuntDefinition.java
+++ b/src/main/java/edu/mit/puzzle/cube/core/HuntDefinition.java
@@ -16,6 +16,15 @@ public interface HuntDefinition {
 
     List<Puzzle> getPuzzles();
 
+    /**
+     * @return A newly constructed CompositeEventProcessor appropriate to the HuntDefinition.
+     * Hunt definitions may override this in order to implement processBatch more efficiently
+     * that the default implementation in EventProcessor.
+     */
+    default CompositeEventProcessor generateCompositeEventProcessor() {
+        return new CompositeEventProcessor();
+    }
+
     void addToEventProcessor(
             CompositeEventProcessor eventProcessor,
             HuntStatusStore huntStatusStore);

--- a/src/main/java/edu/mit/puzzle/cube/core/events/EventProcessor.java
+++ b/src/main/java/edu/mit/puzzle/cube/core/events/EventProcessor.java
@@ -1,7 +1,13 @@
 package edu.mit.puzzle.cube.core.events;
 
+import java.util.List;
+
 public interface EventProcessor<T extends Event> {
 
     public void process(T event);
+
+    default void processBatch(List<? extends T> events) {
+        events.forEach(this::process);
+    }
 
 }

--- a/src/main/java/edu/mit/puzzle/cube/huntimpl/linearexample/LinearExampleHuntDefinition.java
+++ b/src/main/java/edu/mit/puzzle/cube/huntimpl/linearexample/LinearExampleHuntDefinition.java
@@ -3,6 +3,7 @@ package edu.mit.puzzle.cube.huntimpl.linearexample;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
+import com.google.common.collect.ImmutableTable;
 import edu.mit.puzzle.cube.core.HuntDefinition;
 import edu.mit.puzzle.cube.core.events.CompositeEventProcessor;
 import edu.mit.puzzle.cube.core.events.FullReleaseEvent;
@@ -88,9 +89,11 @@ public class LinearExampleHuntDefinition implements HuntDefinition {
         eventProcessor.addEventProcessor(HuntStartEvent.class, event -> {
             boolean changed = huntStatusStore.recordHuntRunStart();
             if (changed) {
-                for (String teamId : huntStatusStore.getTeamIds()) {
-                    huntStatusStore.setVisibility(teamId, "puzzle1", "UNLOCKED", false);
-                }
+                ImmutableTable.Builder<String,String,String> visibilityUpdateBatchBuilder =
+                        ImmutableTable.builder();
+                huntStatusStore.getTeamIds().forEach(teamId ->
+                        visibilityUpdateBatchBuilder.put(teamId, "puzzle1", "UNLOCKED"));
+                huntStatusStore.setVisibilityBatch(visibilityUpdateBatchBuilder.build(), false);
             }
         });
 


### PR DESCRIPTION
I think this is the first step to reducing the processing time at hunt start. There's still going to be processing at the end of a cascade to determine that there are no new actions, but we can at least group together actions that take place simultaneouslish.
